### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ class TestCommand extends ContainerAwareCommand
     {
         $this
             ->addArgument('event', InputArgument::REQUIRED)
-            ->setName('test:event')
+            ->setName('event:processing')
         ;
 
     }


### PR DESCRIPTION
Little typo in command name for symfony exemple
