### PR TITLE
Pass message properties and headers to the executed scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,7 @@ the following.
 {
   "properties": {
     "application_headers": {
-      "name": "value",
-      …
+      "name": "value"
     },
     "content_type": "",
     "content_encoding": "",
@@ -320,7 +319,7 @@ Change your script acording to the following example.
 $input = $argv[1];
 
 // Decode to get original value also decrompress acording to your configuration.
-$data = jsone_decode(base64_decode($input));
+$data = json_decode(base64_decode($input));
 
 // Start processing
 if (do_heavy_lifting($data->body, $data->properties)) {
@@ -362,7 +361,7 @@ class TestCommand extends ContainerAwareCommand
         $data = json_decode(base64_decode($input->getArgument('event')));
         $message = new AMQPMessage($data->body, $data->properties);
 
-        /** @var \PhpAmqpLib\Message\AMQPMessage $consumer */
+        /** @var \PhpAmqpLib\Message\AMQPMessage\ConsumerInterface $consumer */
         $consumer = $this->getContainer()->get('consumer');
 
         if (false == $consumer->execute($message)) {

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -14,14 +14,16 @@ import (
 )
 
 type Consumer struct {
-	Channel     *amqp.Channel
-	Connection  *amqp.Connection
-	Queue       string
-	Factory     *command.CommandFactory
-	ErrLogger   *log.Logger
-	InfLogger   *log.Logger
-	Executer    *command.CommandExecuter
-	Compression bool
+	Channel         *amqp.Channel
+	Connection      *amqp.Connection
+	Queue           string
+	Factory         *command.CommandFactory
+	ErrLogger       *log.Logger
+	InfLogger       *log.Logger
+	Executer        *command.CommandExecuter
+	Compression     bool
+	IncludeMetadata bool
+}
 }
 
 func (c *Consumer) Consume() {

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -11,6 +11,8 @@ import (
 	"github.com/streadway/amqp"
 	"log"
 	"net/url"
+	"encoding/json"
+	"time"
 )
 
 type Consumer struct {
@@ -24,6 +26,21 @@ type Consumer struct {
 	Compression     bool
 	IncludeMetadata bool
 }
+
+type Properties struct{
+	Headers         amqp.Table `json:"application_headers"`
+	ContentType     string     `json:"content_type"`
+	ContentEncoding string     `json:"content_encoding"`
+	DeliveryMode    uint8      `json:"delivery_mode"`
+	Priority        uint8      `json:"priority"`
+	CorrelationId   string     `json:"correlation_id"`
+	ReplyTo         string     `json:"reply_to"`
+	Expiration      string     `json:"expiration"`
+	MessageId       string     `json:"message_id"`
+	Timestamp       time.Time  `json:"timestamp"`
+	Type            string     `json:"type"`
+	UserId          string     `json:"user_id"`
+	AppId           string     `json:"app_id"`
 }
 
 func (c *Consumer) Consume() {
@@ -42,6 +59,34 @@ func (c *Consumer) Consume() {
 	go func() {
 		for d := range msgs {
 			input := d.Body
+			if c.IncludeMetadata {
+				input, err = json.Marshal(&struct {
+					Properties             `json:"properties"`
+					Body        string     `json:"body"`
+				}{
+
+					Properties: Properties {
+						Headers:         d.Headers,
+						ContentType:     d.ContentType,
+						ContentEncoding: d.ContentEncoding,
+						DeliveryMode:    d.DeliveryMode,
+						Priority:        d.Priority,
+						CorrelationId:   d.CorrelationId,
+						ReplyTo:         d.ReplyTo,
+						Expiration:      d.Expiration,
+						MessageId:       d.MessageId,
+						Timestamp:       d.Timestamp,
+						Type:            d.Type,
+						UserId:          d.UserId,
+					},
+
+					Body:            string(d.Body),
+				})
+				if err != nil {
+					c.ErrLogger.Fatalf("Failed to marshall: %s", err)
+					d.Nack(true, true)
+				}
+			}
 			if c.Compression {
 				var b bytes.Buffer
 				w, err := zlib.NewWriterLevel(&b, zlib.BestCompression)

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -77,6 +77,7 @@ func (c *Consumer) Consume() {
 						MessageId:       d.MessageId,
 						Timestamp:       d.Timestamp,
 						Type:            d.Type,
+						AppId:           d.AppId,
 						UserId:          d.UserId,
 					},
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,10 @@ func main() {
 			Name:  "verbose, V",
 			Usage: "Enable verbose mode (logs to stdout and stderr)",
 		},
+		cli.BoolFlag{
+			Name:  "include, i",
+			Usage: "Include metadata. Passes message as JSON data including headers, properties and message body.",
+		},
 	}
 	app.Action = func(c *cli.Context) {
 		if c.String("configuration") == "" && c.String("executable") == "" {
@@ -62,6 +66,7 @@ func main() {
 		if err != nil {
 			errLogger.Fatalf("Failed creating consumer: %s", err)
 		}
+		client.IncludeMetadata = c.Bool("include")
 
 		client.Consume()
 	}


### PR DESCRIPTION
There are use cases where a consumer script needs access to properties and headers of an AMQP message. For that purpose, I have added a flag. If this flag is set, it will change the payload passed to the script. This alternate payload will be a JSON encoded data structure containing not only the body but also includes the messages properties and headers.
