### PR TITLE
Add option to pass in queue name as argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,10 @@ func main() {
 			Name:  "strict-exit-code",
 			Usage: "Strict exit code processing will rise a fatal error if exit code is different from allowed onces.",
 		},
+		cli.StringFlag{
+			Name:  "queue-name, q",
+			Usage: "Optional queue name to which can be passed in, without needing to define it in config, if set will override config queue name",
+		},
 	}
 	app.Action = func(c *cli.Context) {
 		if c.String("configuration") == "" && c.String("executable") == "" {
@@ -50,6 +54,10 @@ func main() {
 
 		logger := log.New(os.Stderr, "", log.Ldate|log.Ltime)
 		cfg, err := config.LoadAndParse(c.String("configuration"))
+
+		if c.String("queue-name") != "" {
+			cfg.RabbitMq.Queue = c.String("queue-name")
+		}
 
 		if err != nil {
 			logger.Fatalf("Failed parsing configuration: %s\n", err)

--- a/main.go
+++ b/main.go
@@ -55,10 +55,6 @@ func main() {
 		logger := log.New(os.Stderr, "", log.Ldate|log.Ltime)
 		cfg, err := config.LoadAndParse(c.String("configuration"))
 
-		if c.String("queue-name") != "" {
-			cfg.RabbitMq.Queue = c.String("queue-name")
-		}
-
 		if err != nil {
 			logger.Fatalf("Failed parsing configuration: %s\n", err)
 		}
@@ -71,6 +67,10 @@ func main() {
 		infLogger, err := createLogger(cfg.Logs.Info, verbose, os.Stdout)
 		if err != nil {
 			logger.Fatalf("Failed creating info log: %s", err)
+		}
+
+		if c.String("queue-name") != "" {
+			cfg.RabbitMq.Queue = c.String("queue-name")
 		}
 
 		factory := command.Factory(c.String("executable"))


### PR DESCRIPTION
Hello,

As discussed in https://github.com/ricbra/rabbitmq-cli-consumer/issues/45 I've gone ahead and made the small tweak to allow the queue name to be passed as an argument, I thought about some of the other arguments, which could possibly be specified, but I think this is ok for now?

Let me know your thoughts.

Kind Regards