### PR TITLE
Convert routingkey from string to []string in configuration files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 		Global bool
 	}
 	QueueSettings struct {
-		Routingkey           string
+		Routingkey           []string
 		MessageTTL           int
 		DeadLetterExchange   string
 		DeadLetterRoutingKey string

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -262,10 +262,12 @@ func New(cfg *config.Config, factory *command.CommandFactory, errLogger, infLogg
 
 		// Bind queue
 		infLogger.Printf("Binding queue \"%s\" to exchange \"%s\"...", cfg.RabbitMq.Queue, cfg.Exchange.Name)
-		err = ch.QueueBind(cfg.RabbitMq.Queue, transformToStringValue(cfg.QueueSettings.Routingkey), transformToStringValue(cfg.Exchange.Name), false, nil)
+                for i := 0; i < len(cfg.QueueSettings.Routingkey); i++ {
+			err = ch.QueueBind(cfg.RabbitMq.Queue, transformToStringValue(cfg.QueueSettings.Routingkey[i]), transformToStringValue(cfg.Exchange.Name), false, nil)
 
-		if nil != err {
-			return nil, errors.New(fmt.Sprintf("Failed to bind queue to exchange: %s", err.Error()))
+			if nil != err {
+				return nil, errors.New(fmt.Sprintf("Failed to bind queue to exchange: %s", err.Error()))
+			}
 		}
 	}
 

--- a/example.conf
+++ b/example.conf
@@ -19,6 +19,8 @@ durable=On
 
 [queuesettings]
 routingkey=somekey
+routingkey=secondkey
+routingkey=thirdkey
 messagettl=30000
 deadLetterExchange=someexchange
 deadLetterroutingkey=someroutingkey


### PR DESCRIPTION
It permit to bind one queue to one exchange with more than one routing key.

Fix #53.